### PR TITLE
Enable runtime commands for GrokParty

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ python main.py
 
 ## Controls
 
-- **p**: Pause or resume the conversation
-- **s**: Stop the conversation
-- **e**: Export the conversation history as JSON
+- **p**: Pause or resume the conversation (no Enter needed)
+- **s**: Stop the conversation (no Enter needed)
+- **e**: Export the conversation history as JSON (no Enter needed)
 - **Ctrl+C**: Quit immediately
 - **New Conversation**: Start fresh with new parameters
 
@@ -109,7 +109,7 @@ Describe character 3's personality [Character 3]: A pragmatic engineer
 Select model for A pragmatic engineer (1-5) [1]: 3
 
 Starting conversation...
-Type 'p' to pause, 's' to stop, 'e' to export or Ctrl+C to quit
+Press 'p' to pause, 's' to stop, 'e' to export or Ctrl+C to quit
 ```
 
 ## File Structure

--- a/grokparty/models/conversation.py
+++ b/grokparty/models/conversation.py
@@ -95,11 +95,12 @@ class Conversation:
     async def _continue_conversation(self, grok_api):
         """Continue the conversation loop"""
         try:
-            while self.is_active and not self.is_paused:
+            while self.is_active:
+                if self.is_paused:
+                    await asyncio.sleep(0.5)
+                    continue
+
                 await asyncio.sleep(2)  # Brief pause between messages
-                
-                if not self.is_active or self.is_paused:
-                    break
                 
                 # Determine next speaker
                 next_speaker = await self.determine_next_speaker(grok_api)


### PR DESCRIPTION
## Summary
- allow pausing, stopping and exporting while a conversation runs
- document new keyboard controls

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688d4cf5bf4483279c307e9df42ad574